### PR TITLE
Fix #167: _retrieve_job uses qacct to get info about jobs not in the qstat queue

### DIFF
--- a/saga/adaptors/sge/sgejob.py
+++ b/saga/adaptors/sge/sgejob.py
@@ -375,7 +375,7 @@ class SGEJobService (saga.adaptors.cpi.job.Service):
                     self.pe_list.append(pe)
             self._logger.debug("Available processing elements: %s" %
                 (self.pe_list))
-         
+
         # find out mandatory and optional memory attributes 
         ret, out, _ = self.shell.run_sync('%s -sc' % (self._commands['qconf']['path']))
         if ret != 0:


### PR DESCRIPTION
Hi, I send a pull request with the modifications made to the SGE adaptor to support retrieving job information for jobs that go out of the qstat queue using accounting information.

The SGE CLI interface is the worst I have seen ever and have some issues. One of them, that I can not understand, is that when you run _qstat -j job_id_ you don't get the state of the job nor the start_time. To get this information you have to run another _qstat_ process without _-j_ and parse the output. Other issue is that when a job finishes/fails it goes out immediately from the _qstat_ list. Here there are two possibilities: If accounting information is not activated then we don't have any chance to get the information unless a wise mystic inquire. In the lucky case that it is activated then there is a gap in time between the job goes out of _qstat_ queue and when it is available through _qacct_ (sometimes few seconds, other times more than 10 seconds in my virtual machine). I implemented the retrieval of job information through _qacct_ in a separate function ( ___job_info_from_accounting_ ). There, there is a maximum number of 10 trials with lapses of 1 second before a None is returned (and consequently an exception is raised). This makes some job operations quite slow and prone to error when the job limbo time exceeds 10 seconds approx. It is possible to know whether accounting is activated or not (using _qconf -sconf | grep accounting=true_) and avoid the _qacct_ part in case it is not but I have not implemented it.

Other way to address this issue would be to take the approach proposed in #180 and maintain a remote process open all the time acting like a server and using _DRMAA_ to send jobs, get status, ... It would be a bit complicated, and in the case that you loose the _DRMAA_ session (network cut, ...) when reconnecting you would have lost those jobs that finished while _DRMAA_ process was off ( _DRMAA_ 1.0 doesn't have session persistence guaranteed). Furthermore, IT's restrict the maximum time per process in the submission host usually.

So, no other solution comes to my mind apart from waiting for _DRMAA_ 2.0 implementation or Open Grid Scheduler team takes care of fixing CLI interface (which I don't think).

Sorry for my hard words about SGE but was frustrating trying to find a solution with which I felt comfortable enough.

Note that I run the tests and fixed the _job.exit_code_ test with this fix but still _job.suspend()/resume()_ and _submit a job via run_job, and retrieve id_ are failing.
