### PR TITLE
fix key_pass not being indexed by user_key

### DIFF
--- a/saga/utils/pty_shell_factory.py
+++ b/saga/utils/pty_shell_factory.py
@@ -659,7 +659,7 @@ class PTYShellFactory (object) :
                                     info['sftp_args'] += "-o IdentityFile=%s " % context.user_key 
 
                                     if  context.attribute_exists ("user_pass") and context.user_pass :
-                                        info['key_pass'][context.user_cert] = context.user_pass
+                                        info['key_pass'][context.user_key] = context.user_pass
 
                         if  context.type.lower () == "userpass" :
                             if  info['schema'] in _SCHEMAS_SSH + _SCHEMAS_GSI :


### PR DESCRIPTION
Encrypted private ssh keys are not being decrypted and an exception is raised instead.

After 37011e1a028470dbe6501053b06e097d678b4fc5 (merge from devel), passphrases
were stored in a dict indexed by user_cert.

A later commit ca68c59f2d97303fb359541735e0ac2e11c4d3fa (fix key mishap),
partially undid that change so that the options for the ssh command were
right (--IdentityFile references context.user_key, i.e. the private key).
However, line 544 was not updated and the user_pass is still stored in a
dictionary indexed by context.user_cert (i.e. the public key).

This dictionary is used later on (line 291) when the prompt asks for a passphrase
to decrypt the private key. The passphrase is not found, because it was stored
relative to the public key, and an exception is raised.

Note how this is also inconsistent with the behaviour in saga/adaptors/context/ssh.py:285
were that same passphrase is expected to decrypt the private key.
