### PR TITLE
slurm get job state

### DIFF
--- a/saga/adaptors/slurm/slurm_job.py
+++ b/saga/adaptors/slurm/slurm_job.py
@@ -673,7 +673,7 @@ class SLURMJobService (saga.adaptors.cpi.job.Service) :
                 # if no match, we have no exitcode
                 else:
                     self.exit_code = None
-                    
+
                 self._logger.debug("Returning exit code %s" % self.exit_code)
                 
                 # return whatever our exit code is
@@ -1014,12 +1014,17 @@ class SLURMJob (saga.adaptors.cpi.job.Job):
             ret, out, _ = self.js.shell.run_sync('scontrol show job %s' % pid)
             m = self.js.scontrol_jobstate_re.search(out)
             if m:
-                scontrol_state = m.group(0)
+                slurm_state = m.group(0)
             else:
                 # no jobstate found from scontrol
-                return saga.job.UNKNOWN
+                # the job may have finished a while back, use sacct to
+                # look at the full slurm history
+                slurm_state = self._sacct_jobstate_match(pid)
+                if not slurm_state:
+                    # no jobstate found in slurm
+                    return saga.job.UNKNOWN
 
-            return self.js._slurm_to_saga_jobstate(scontrol_state)
+            return self.js._slurm_to_saga_jobstate(slurm_state)
 
         except Exception, ex:
             raise saga.NoSuccess("Error getting the job state for "
@@ -1028,6 +1033,24 @@ class SLURMJob (saga.adaptors.cpi.job.Job):
         raise saga.NoSuccess._log (self._logger,
                                    "Internal SLURM adaptor error"
                                    " in _job_get_state")
+
+    def _sacct_jobstate_match (self, pid):
+        """ get the job state from the slurm accounting data """
+        ret, sacct_out, _ = self.js.shell.run_sync(
+            "sacct --format=JobID,State --parsable2 --noheader --jobs=%s" % pid)
+        # output will look like:
+        # 500723|COMPLETED
+        # 500723.batch|COMPLETED
+        # or:
+        # 500682|CANCELLED by 900369
+        # 500682.batch|CANCELLED
+
+        for line in sacct_out.strip().split('\n'):
+            (slurm_id, slurm_state) = line.split('|', 1)
+            if slurm_id == pid and slurm_state:
+                return slurm_state.split()[0].strip()
+
+        return None
 
     # ----------------------------------------------------------------
     #


### PR DESCRIPTION
There's two small problems when getting the state of a job that has been run on a slurm queue:
1- If the job got cancelled externally, saga is not picking up the new state due to a typo (it works if cancelling via saga because we directly set the state in job.cancel())

2 - If the job state hasn't been queried for long enough, slurm removes it from the loaded data and scontrol cannot find it anymore. This seems to be a poorly documented slurm feature. There's a mention of it here: https://gitlab.com/sol/mc2-agent/issues/8

However, sacct does have access to the history of all run jobs and can provide the correct state.
