### PR TITLE
Fixing adaptors to pass tests

### DIFF
--- a/src/radical/saga/adaptors/cobalt/cobaltjob.py
+++ b/src/radical/saga/adaptors/cobalt/cobaltjob.py
@@ -208,7 +208,7 @@ def _cobaltscript_generator(url, logger, jd, ppn, is_cray=False, queue=None,
             cobalt_params += '#COBALT --error %s\n' % jd.error
 
     if jd.wall_time_limit:
-        hours = jd.wall_time_limit / 60
+        hours = int(jd.wall_time_limit / 60)
         minutes = jd.wall_time_limit % 60
         cobalt_params += '#COBALT --time %s:%s:00\n' \
             % (str(hours).zfill(2), str(minutes).zfill(2))

--- a/src/radical/saga/adaptors/loadl/loadljob.py
+++ b/src/radical/saga/adaptors/loadl/loadljob.py
@@ -485,7 +485,7 @@ class LOADLJobService (cpi.job.Service):
         if jd.error is not None:
             loadl_params += "#@ error = %s\n" % jd.error
         if jd.wall_time_limit is not None:
-            hours = jd.wall_time_limit / 60
+            hours = int(jd.wall_time_limit / 60)
             minutes = jd.wall_time_limit % 60
             loadl_params += "#@ wall_clock_limit = %s:%s:00\n" \
                 % (str(hours), str(minutes))

--- a/src/radical/saga/adaptors/pbs/pbsjob.py
+++ b/src/radical/saga/adaptors/pbs/pbsjob.py
@@ -217,7 +217,7 @@ def _pbscript_generator(url, logger, jd, ppn, gres, pbs_version, is_cray=False,
 
 
     if jd.wall_time_limit:
-        hours = jd.wall_time_limit / 60
+        hours = int(jd.wall_time_limit / 60)
         minutes = jd.wall_time_limit % 60
         pbs_params += "#PBS -l walltime=%s:%s:00 \n" \
             % (str(hours), str(minutes))

--- a/src/radical/saga/adaptors/pbspro/pbsprojob.py
+++ b/src/radical/saga/adaptors/pbspro/pbsprojob.py
@@ -244,7 +244,7 @@ def _script_generator(url, logger, jd, ppn, gres, version, is_cray=False,
 
 
     if jd.wall_time_limit:
-        hours = jd.wall_time_limit / 60
+        hours = int(jd.wall_time_limit / 60)
         minutes = jd.wall_time_limit % 60
         pbs_params += "#PBS -l walltime=%s:%s:00 \n" \
             % (str(hours), str(minutes))

--- a/src/radical/saga/adaptors/sge/sgejob.py
+++ b/src/radical/saga/adaptors/sge/sgejob.py
@@ -695,7 +695,7 @@ class SGEJobService (cpi.Service):
             sge_params += ["#$ -e %s" % jd.error]
 
         if jd.wall_time_limit is not None:
-            hours = jd.wall_time_limit / 60
+            hours = int(jd.wall_time_limit / 60)
             minutes = jd.wall_time_limit % 60
             sge_params += ["#$ -l h_rt=%s:%s:00" % (str(hours), str(minutes))]
 

--- a/src/radical/saga/adaptors/slurm/slurm_job.py
+++ b/src/radical/saga/adaptors/slurm/slurm_job.py
@@ -558,7 +558,7 @@ class SLURMJobService(cpi_job.Service):
         if account    : script += "#SBATCH --account %s\n"     % account
         if reservation: script += "#SBATCH --reservation %s\n" % reservation
         if wall_time  : script += "#SBATCH --time %02d : %02d : 00\n" \
-                                              % (wall_time / 60, wall_time % 60)
+                                              % (int(wall_time / 60), wall_time % 60)
         if env:
             script += "\n## ENVIRONMENT\n"
             for key,val in env.items():

--- a/src/radical/saga/adaptors/slurm/slurm_job.py
+++ b/src/radical/saga/adaptors/slurm/slurm_job.py
@@ -557,7 +557,7 @@ class SLURMJobService(cpi_job.Service):
         if job_contact: script += "#SBATCH --mail-user=%s\n"   % job_contact
         if account    : script += "#SBATCH --account %s\n"     % account
         if reservation: script += "#SBATCH --reservation %s\n" % reservation
-        if wall_time  : script += "#SBATCH --time %02d : %02d : 00\n" \
+        if wall_time  : script += "#SBATCH --time %02d:%02d:00\n" \
                                               % (int(wall_time / 60), wall_time % 60)
         if env:
             script += "\n## ENVIRONMENT\n"

--- a/src/radical/saga/adaptors/slurm/slurm_job.py
+++ b/src/radical/saga/adaptors/slurm/slurm_job.py
@@ -502,11 +502,11 @@ class SLURMJobService(cpi_job.Service):
         self._logger.debug ("submit SLURM script to %s", self.rm)
         if 'bridges' in self.rm.host.lower():
 
-            if total_gpu_count:
+            if gpu_count:
                 # gres resouurces are specified *per node*
                 assert(self._ppn), 'need unique number of cores per node'
-                number_of_nodes = int(math.ceil(float(total_cpu_count) / self._ppn))
-                count = int(total_gpu_count / number_of_nodes)
+                number_of_nodes = int(math.ceil(float(cpu_count) / self._ppn))
+                count = int(gpu_count / number_of_nodes)
 
                 if count:
                     if cpu_arch: gpu_arch = cpu_arch.lower()
@@ -519,12 +519,12 @@ class SLURMJobService(cpi_job.Service):
 
         elif 'tiger' in self.rm.host.lower():
 
-            if total_gpu_count:
+            if gpu_count:
 
                 # gres resouurces are specified *per node*
                 assert(self._ppn), 'need unique number of cores per node'
-                number_of_nodes = int(math.ceil(float(total_cpu_count) / self._ppn))
-                count = int(total_gpu_count / number_of_nodes)
+                number_of_nodes = int(math.ceil(float(cpu_count) / self._ppn))
+                count = int(gpu_count / number_of_nodes)
 
                 if count:
                     script += "#SBATCH --gres=gpu:%s\n" % count

--- a/src/radical/saga/adaptors/torque/torquejob.py
+++ b/src/radical/saga/adaptors/torque/torquejob.py
@@ -252,7 +252,7 @@ def _script_generator(url, logger, jd, ppn, gpn, gres, version,
 
 
     if jd.wall_time_limit:
-        hours = jd.wall_time_limit / 60
+        hours = int(jd.wall_time_limit / 60)
         minutes = jd.wall_time_limit % 60
         pbs_params += "#PBS -l walltime=%s:%s:00 \n" \
             % (str(hours), str(minutes))


### PR DESCRIPTION
This fixes #742 

All walltime divisions were not converted to integers for the hours when batch scripts were created