### PR TITLE
traverse support

### DIFF
--- a/src/radical/saga/__init__.py
+++ b/src/radical/saga/__init__.py
@@ -4,6 +4,11 @@ __copyright__ = "Copyright 2013, RADICAL"
 __license__   = "MIT"
 
 
+import urllib
+import cgi
+cgi.parse_qs = urllib.parse.parse_qs
+
+
 # ------------------------------------------------------------------------------
 #
 

--- a/src/radical/saga/adaptors/slurm/slurm_job.py
+++ b/src/radical/saga/adaptors/slurm/slurm_job.py
@@ -398,6 +398,9 @@ class SLURMJobService(cpi_job.Service):
             # FIXME: this only works on the KNL nodes
             self._ppn = 68
 
+        elif 'traverse' in self.rm.host.lower():
+            self._ppn = 32
+
         elif 'frontera' in self.rm.host.lower():
             self._ppn = 56
 
@@ -620,6 +623,7 @@ class SLURMJobService(cpi_job.Service):
             if 'frontera' in self.rm.host.lower() or \
                'longhorn' in self.rm.host.lower() or \
                'tiger'    in self.rm.host.lower() or \
+               'traverse' in self.rm.host.lower() or \
                'rhea'     in self.rm.host.lower():
                 script += "#SBATCH --chdir %s\n"   % cwd
             else:


### PR DESCRIPTION
also ensure baclward compatibility for cgi module (`parse_qs` is not exported anymore, but needs to be pulled from `urllib`).  I'll open a ticket for a proper cleanup.