### PR TITLE
Fix bridges GPU gres flag

### DIFF
--- a/src/radical/saga/adaptors/slurm/slurm_job.py
+++ b/src/radical/saga/adaptors/slurm/slurm_job.py
@@ -599,7 +599,7 @@ class SLURMJobService(cpi_job.Service):
                 if count:
                     if cpu_arch: gpu_arch = cpu_arch.lower()
                     else       : gpu_arch = 'p100'
-                    script += "#SBATCH --gres=gpu:%s:%s\n" % (gpu_arch, count)
+                    script += "#SBATCH --gres=gpu:%s:2\n" % (gpu_arch)
 
             # use '-C EGRESS' to enable outbound network
             script += "#SBATCH -C EGRESS\n"

--- a/src/radical/saga/adaptors/slurm/slurm_job.py
+++ b/src/radical/saga/adaptors/slurm/slurm_job.py
@@ -599,7 +599,7 @@ class SLURMJobService(cpi_job.Service):
                 if count:
                     if cpu_arch: gpu_arch = cpu_arch.lower()
                     else       : gpu_arch = 'p100'
-                    script += "#SBATCH --gres=gpu:%s:2\n" % (gpu_arch)
+                    script += "#SBATCH --gres=gpu:%s:2\n" % (gpu_arch)  # Make sure we take a full GPU node
 
             # use '-C EGRESS' to enable outbound network
             script += "#SBATCH -C EGRESS\n"


### PR DESCRIPTION
Bridges require to define the GPUs per node in the gres flag. So when we are requesting `p100` the gres should look like `--gres=gpu:p100:2` for any number of GPUS.

This is a hot fix since we are not supporting any other GPU type on Bridges.