### PR TITLE
Remove redis-adaptor loading

### DIFF
--- a/src/radical/saga/configs/registry_default.json
+++ b/src/radical/saga/configs/registry_default.json
@@ -11,7 +11,7 @@
         "radical.saga.adaptors.shell.shell_job",
         "radical.saga.adaptors.shell.shell_file",
         "radical.saga.adaptors.shell.shell_resource",
-        "radical.saga.adaptors.redis.redis_advert",
+      # "radical.saga.adaptors.redis.redis_advert",
         "radical.saga.adaptors.sge.sgejob",
       # "radical.saga.adaptors.pbs.pbsjob",
         "radical.saga.adaptors.lsf.lsfjob",


### PR DESCRIPTION
Should some other adaptors be removed (comment out in config) from the loading as well?

p.s. Redis adaptor is not removed completely, just not loading (if there will be a request for it, then it can be turned on and some it parts should be updated according to the latest version of RU)