### PR TITLE
fix sh timeout for long running sessions

### DIFF
--- a/src/radical/saga/adaptors/shell/shell_job.py
+++ b/src/radical/saga/adaptors/shell/shell_job.py
@@ -502,6 +502,9 @@ class ShellJobService(cpi.Service):
             # When should that be done?
 
             with self._shell_lock:
+                # cancel scheduled `PING` request
+                self._ping.cancel()
+
              #  self.shell.run_sync("PURGE", iomode=None)
                 self.shell.run_async("QUIT")
                 self.shell.finalize(kill_pty=True)

--- a/src/radical/saga/adaptors/shell/shell_job.py
+++ b/src/radical/saga/adaptors/shell/shell_job.py
@@ -386,6 +386,7 @@ class Adaptor(base.Base):
             return
 
         if jd.file_transfer is not None:
+
             td = TransferDirectives(jd.file_transfer)
 
             if td.in_append or td.out_append:
@@ -396,7 +397,9 @@ class Adaptor(base.Base):
                     source = local
                     target = remote
                     self._logger.info("stage %s to %s" % (source, target))
-                    shell.stage_to_remote(source, target)
+
+                    with self._shell_lock:
+                        shell.stage_to_remote(source, target)
 
 
     # --------------------------------------------------------------------------
@@ -417,7 +420,9 @@ class Adaptor(base.Base):
                     source = remote
                     target = local
                     self._logger.info("stage %s to %s" % (source, target))
-                    shell.stage_from_remote(source, target)
+
+                    with self._shell_lock:
+                        shell.stage_from_remote(source, target)
 
 
 # ------------------------------------------------------------------------------
@@ -720,8 +725,7 @@ class ShellJobService(cpi.Service):
         '''
 
         # stage data, then run job
-        with self._shell_lock:
-            self._adaptor.stage_input(self.shell, jd)
+        self._adaptor.stage_input(self.shell, jd)
 
         # create command to run
         cmd = self._jd2cmd(jd)

--- a/src/radical/saga/adaptors/shell/shell_wrapper.sh
+++ b/src/radical/saga/adaptors/shell/shell_wrapper.sh
@@ -158,6 +158,7 @@ idle_checker () {
       exit 0
     fi
 
+    \echo "timeout test: ok"
     \touch "$BASE/idle.$ppid"
   done
 }
@@ -824,7 +825,6 @@ cmd_purge () {
 #
 cmd_ping () {
 
-  echo "ping $(date %+s >> /tmp/t)"
   RETVAL="PONG"
 }
 

--- a/src/radical/saga/adaptors/shell/shell_wrapper.sh
+++ b/src/radical/saga/adaptors/shell/shell_wrapper.sh
@@ -158,7 +158,6 @@ idle_checker () {
       exit 0
     fi
 
-    \echo "timeout test: ok"
     \touch "$BASE/idle.$ppid"
   done
 }

--- a/src/radical/saga/adaptors/shell/shell_wrapper.sh
+++ b/src/radical/saga/adaptors/shell/shell_wrapper.sh
@@ -820,6 +820,17 @@ cmd_purge () {
 
 # --------------------------------------------------------------------
 #
+# ping shell to ensure it is not hitting idle timeout
+#
+cmd_ping () {
+
+  echo "ping $(date %+s >> /tmp/t)"
+  RETVAL="PONG"
+}
+
+
+# --------------------------------------------------------------------
+#
 # purge tmp files for bulks etc.
 #
 # NOTE: we need to be able to handle unremovable nsf lockfiles (`|| true`)
@@ -957,6 +968,7 @@ listen() {
         LOG       ) cmd_log     "$ARGS"  ;;
         LIST      ) cmd_list    "$ARGS"  ;;
         PURGE     ) cmd_purge   "$ARGS"  ;;
+        PING      ) cmd_ping    "$ARGS"  ;;
         QUIT      ) cmd_quit    "$IDLE"  ;;
         HELP      ) cat <<EOT
 
@@ -965,6 +977,7 @@ listen() {
         MONITOR            - monitor for events
         PURGE              - purge completed jobs
         NOOP               - do nothing
+        PING               - update keepalive timer
         QUIT               - quit
         RUN     <cmd>      - run a job, prints job ID
         LRUN               - multiline run

--- a/src/radical/saga/utils/pty_shell.py
+++ b/src/radical/saga/utils/pty_shell.py
@@ -28,7 +28,7 @@ from  ..import exceptions         as rse
 # ------------------------------------------------------------------------------
 #
 _PTY_TIMEOUT = 2.0
-_PING_DELAY  = 2.0
+
 
 # ------------------------------------------------------------------------------
 #
@@ -227,22 +227,6 @@ class PTYShell (object) :
         self.prompt_re = re.compile ("^(.*?)%s"    % self.prompt, re.DOTALL)
         self.logger.info ("PTY prompt pattern: %s" % self.prompt)
 
-        # the underlying shell is not always ready to receive new commands,
-        # e.g.,  when running an async command and still collecting output.
-        # The driving code is usually aware of the shell's state - but we want
-        # to send `PING` requests now and then to ensure the shell does not
-        # time out, and the thread triggering that ping is *not* aware of the
-        # shell state.  To avoid interfering with async calls, we mark the shell
-        # as `dirty` while it is in a state where it cannot receive new
-        # commands.
-        self._dirty = mt.Event()
-        self._dirty.clear()
-
-        # at regular intervals, run a ping toward the shell wrapper to avoid
-        # timeouts kicking in
-        # FIXME: configurable frequency
-        self._ping = mt.Timer(_PING_DELAY, self._ping_cb)
-
         # we need a local dir for file staging caches.  At this point we use
         # $HOME, but should make this configurable (FIXME)
         self.base = os.environ['HOME'] + '/.radical/saga/adaptors/shell/'
@@ -268,16 +252,6 @@ class PTYShell (object) :
         self._trace ('init : %s' % self.pty_shell.command)
 
         self.initialize ()
-
-
-    # ----------------------------------------------------------------
-    #
-    def _ping_cb (self) :
-
-        pong = self.run_sync('PING')
-        assert(pong == 'PONG\n')
-
-        self._ping = mt.Timer(_PING_DELAY, self._ping_cb)
 
 
     # ----------------------------------------------------------------
@@ -415,8 +389,6 @@ class PTYShell (object) :
               #                  % (self.prompt, match))
                 ret, txt = self._eval_prompt (match)
 
-                # a prompt detection clears the shell
-                self._dirty.clear
                 return (ret, txt)
 
             except Exception as e :
@@ -708,9 +680,6 @@ class PTYShell (object) :
                 if iomode == STDOUT  : redir  =  " 2>/dev/null"
                 if iomode == STDERR  : redir  =  " 2>&1 1>/dev/null"
 
-                # the shell is dirty while cmd is in progress
-                self._dirty.set()
-
                 self.logger.debug    ('run_sync: %s%s'   % (command, redir))
                 self.pty_shell.write (          "%s%s\n" % (command, redir))
 
@@ -768,9 +737,6 @@ class PTYShell (object) :
             except Exception as e :
                 raise ptye.translate_exception (e) from e
 
-            finally:
-                self._dirty.clear()
-
 
     # ----------------------------------------------------------------
     #
@@ -801,10 +767,6 @@ class PTYShell (object) :
                                       % self.pty_shell.autopsy ())
 
             try :
-                # the shell is dirty while cmd is in progress.
-                # `self.find_prompt()` will have to be called to undirty it.
-                self._dirty.set()
-
                 command = command.strip ()
                 self.send ("%s\n" % command)
 
@@ -820,10 +782,6 @@ class PTYShell (object) :
         """
 
         with self.pty_shell.rlock :
-            # any ongoing data write marks the shell dirty
-            # self.find_prompt will have to be called to clear
-            self._dirty.set()
-
 
             if not self.pty_shell.alive (recover=False) :
                 raise rse.IncorrectState("Cannot send data:\n%s"
@@ -855,10 +813,6 @@ class PTYShell (object) :
         """
 
         try :
-
-            # any ongoing data write marks the shell dirty - find_prompt() will
-            # have to be called to clear
-            self._dirty.set()
 
           # self._trace ("write     : %s -> %s" % (src, tgt))
 
@@ -939,16 +893,10 @@ class PTYShell (object) :
         # prompt, and updating pwd state on every find_prompt.
 
         try :
-            # any ongoing data write marks the shell dirty
-            self._dirty.set()
-
             return self.run_copy_to (src, tgt, cp_flags)
 
         except Exception as e :
             raise ptye.translate_exception (e) from e
-
-        finally:
-            self._dirty.clear
 
 
     # ----------------------------------------------------------------
@@ -976,9 +924,6 @@ class PTYShell (object) :
 
         except Exception as e :
             raise ptye.translate_exception (e) from e
-
-        finally:
-            self._dirty.clear
 
 
     # --------------------------------------------------------------------------

--- a/src/radical/saga/utils/pty_shell.py
+++ b/src/radical/saga/utils/pty_shell.py
@@ -10,8 +10,6 @@ import sys
 import errno
 import tempfile
 
-import threading as mt
-
 import radical.utils              as ru
 
 from  .  import misc              as sumisc
@@ -336,10 +334,6 @@ class PTYShell (object) :
                     if not self.finalized :
                         self.pty_shell.finalize ()
                         self.finalized = True
-
-            # cancle ping timer if needed
-            if self._ping:
-                self._ping.cancel()
 
         except Exception:
             pass

--- a/tests/unittests/api/job/test_service.py
+++ b/tests/unittests/api/job/test_service.py
@@ -36,7 +36,6 @@ def _silent_close_js(js_obj):
     # try to cancel job but silently ignore all errors
     try:
         js_obj.close()
-        js_obj.close()
     except Exception:
         pass
 
@@ -232,6 +231,7 @@ def helper_multiple_services(i):
     assert (j2.state == rs.job.DONE)
 
     _silent_close_js(js1)
+    _silent_close_js(js2)
 
 
 # ------------------------------------------------------------------------------

--- a/tests/unittests/api/job/test_service.py
+++ b/tests/unittests/api/job/test_service.py
@@ -214,7 +214,7 @@ def helper_multiple_services(i):
     jd  = rs.job.Description()
 
     jd.executable = '/bin/sleep'
-    jd.arguments  = ['1']
+    jd.arguments  = ['3']
     jd = sutc.configure_jd(cfg=cfg, jd=jd)
 
     j1 = js1.create_job(jd)
@@ -236,10 +236,12 @@ def helper_multiple_services(i):
 
 # ------------------------------------------------------------------------------
 #
-NUM_SERVICES = 20
+NUM_SERVICES = 5
 
 def test_multiple_services():
-    """ Test to create multiple job service instances  (this test might take a while) """
+    """
+    test concurrent job services (takes a while)
+    """
     import threading as mt
     import queue
 


### PR DESCRIPTION
This adds an infrequent keepalive-`ping` between service instance and shell_wrapper so that the shell timeout does not kick in as long as the connection is up.