### PR TITLE
Fix for ShellJob[Service]

### DIFF
--- a/src/radical/saga/adaptors/shell/shell_job.py
+++ b/src/radical/saga/adaptors/shell/shell_job.py
@@ -1468,7 +1468,8 @@ class ShellJob(cpi.Job):
             # stage output data
             # FIXME: _update_state blocks until data are staged.
             #        That should not happen.
-            self._adaptor.stage_output(self.js.shell, self._shell_lock, self.jd)
+            self._adaptor.stage_output(self.js.shell, self.js._shell_lock,
+                                       self.jd)
 
         # files are staged -- update state, and report to application
         self._state = state


### PR DESCRIPTION
Inside `ShellJob` there are several methods (`get_stdout`, `get_stderr`, `get_log`) that have a call `self.js.shell.run_sync`, should it be put into `with self.js._shell_lock:` construction?