### PR TITLE
comet takes --gres for gpu

### DIFF
--- a/src/radical/saga/adaptors/slurm/slurm_job.py
+++ b/src/radical/saga/adaptors/slurm/slurm_job.py
@@ -625,11 +625,13 @@ class SLURMJobService(cpi_job.Service):
                 # gres resources are specified *per node*
                 assert(n_nodes), 'need unique number of cores per node'
 
-                if gpu_arch: gpu_arch = gpu_arch.lower()
-                else       : gpu_arch = 'p100'
+                # if no `gpu_arch` then first available gpu node (either type)
+                # gpu types are "p100" and "k80"
+                if gpu_arch: gpu_arch_str = ':%s' % gpu_arch.lower()
+                else       : gpu_arch_str = ''
                 count = 4
                 # Make sure we take a full GPU node
-                script += "#SBATCH --gres=gpu:%s:%d\n" % (gpu_arch, count)
+                script += "#SBATCH --gres=gpu%s:%d\n" % (gpu_arch_str, count)
 
         elif 'tiger' in self.rm.host.lower():
 

--- a/src/radical/saga/adaptors/slurm/slurm_job.py
+++ b/src/radical/saga/adaptors/slurm/slurm_job.py
@@ -619,6 +619,18 @@ class SLURMJobService(cpi_job.Service):
             # use '-C EGRESS' to enable outbound network
             script += "#SBATCH -C EGRESS\n"
 
+        elif 'comet' in self.rm.host.lower():
+
+            if gpu_count:
+                # gres resources are specified *per node*
+                assert(n_nodes), 'need unique number of cores per node'
+
+                if gpu_arch: gpu_arch = gpu_arch.lower()
+                else       : gpu_arch = 'p100'
+                count = 4
+                # Make sure we take a full GPU node
+                script += "#SBATCH --gres=gpu:%s:%d\n" % (gpu_arch, count)
+
         elif 'tiger' in self.rm.host.lower():
 
             if gpu_count:


### PR DESCRIPTION
This is to reflect slurm options for gpus, and addressing issue #813 according to https://portal.xsede.org/sdsc-comet#gpu.
