### PR TITLE
ip-isolate flag for distributed pytorch on lassen

### DIFF
--- a/src/radical/saga/adaptors/lsf/lsfjob.py
+++ b/src/radical/saga/adaptors/lsf/lsfjob.py
@@ -50,7 +50,8 @@ RESOURCES = {
                ]},
     'lassen': {'cpn': 40,
                'gpn': 4,
-               'valid_alloc_flags': []}
+               'valid_alloc_flags': [
+                   'ipisolate']}
 }
 
 

--- a/src/radical/saga/adaptors/lsf/lsfjob.py
+++ b/src/radical/saga/adaptors/lsf/lsfjob.py
@@ -51,7 +51,11 @@ RESOURCES = {
     'lassen': {'cpn': 40,
                'gpn': 4,
                'valid_alloc_flags': [
-                   'ipisolate']}
+                   'atsdisable',
+                   'autonumaoff',
+                   'cpublink',
+                   'ipisolate'
+               ]}
 }
 
 


### PR DESCRIPTION
This PR aims to introduce `"-alloc_flags ipisolate"` for lsf jobs on Lassen. One use case is that distributed pytorch requires sockets opened without authentication, which isn't abiding LC security policy. This flag is accommodating with the system, and for more details: https://lc.llnl.gov/confluence/pages/viewpage.action?pageId=650674651