### PR TITLE
fixing python deprecation

### DIFF
--- a/src/radical/saga/task.py
+++ b/src/radical/saga/task.py
@@ -424,7 +424,7 @@ class Container (sbase.SimpleBase, satt.Attributes) :
 
         # wait for all futures to finish
         for future in futures :
-            if  future.isAlive () :
+            if  future.is_alive () :
                 future.join ()
 
             if  future.state == c.FAILED :
@@ -497,7 +497,7 @@ class Container (sbase.SimpleBase, satt.Attributes) :
             if future.state == c.FAILED :
                 raise future.exception
 
-            if not future.isAlive() :
+            if not future.is_alive() :
                 # future indeed finished -- dig return value from this
                 # futures queue
                 result = future.result


### PR DESCRIPTION
Thread objects deprecated `isAlive` from python version 3.7 in favor of `is_alive`:
```
(base) iparask@js-17-185:$ conda create -n test python=3.7 -y;conda activate test;python -c 'import threading as mt;t = mt.Thread();print(t.isAlive.__doc__);exit();';conda deactivate;conda remove --all -n test -y

Return whether the thread is alive.

        This method is deprecated, use is_alive() instead.

(base) iparask@js-17-185:$ conda create -n test python=3.6 -y;conda activate test;python -c 'import threading as mt;t = mt.Thread();print(t.is_alive.__doc__);exit();';conda deactivate;conda remove --all -n test -y

Return whether the thread is alive.

        This method returns True just before the run() method starts until just
        after the run() method terminates. The module function enumerate()
        returns a list of all alive threads.

(base) iparask@js-17-185:$ conda create -n test python=3.5 -y;conda activate test;python -c 'import threading as mt;t = mt.Thread();print(t.is_alive.__doc__);exit();';conda deactivate;conda remove --all -n test -y

Return whether the thread is alive.

        This method returns True just before the run() method starts until just
        after the run() method terminates. The module function enumerate()
        returns a list of all alive threads.

(base) iparask@js-17-185:$
```