### PR TITLE
longhorn GRES exception

### DIFF
--- a/src/radical/saga/adaptors/slurm/slurm_job.py
+++ b/src/radical/saga/adaptors/slurm/slurm_job.py
@@ -641,6 +641,9 @@ class SLURMJobService(cpi_job.Service):
             if cpu_arch : script += "#SBATCH -C %s\n"     % cpu_arch
             if gpu_count: script += "#SBATCH --gpus=%s\n" % gpu_count
 
+        elif 'longhorn' in self.rm.host.lower():
+            self._logger.debug("SLURM GRES is not set (longhorn exception)\n")
+
         elif queue == 'tmp3':
 
             # this is a special queue, which is associated with SuperMUC-NG,


### PR DESCRIPTION
To respond to #835 , GRES option is excluded from the Longhorn slurm script,
```
            if gpu_count: script += "#SBATCH --gpus=%s\n" % gpu_count
```
is eliminated when host is `longhorn`.