### PR TITLE
SAGA.Exception should not overwrite representation

### DIFF
--- a/src/radical/saga/exceptions.py
+++ b/src/radical/saga/exceptions.py
@@ -142,18 +142,6 @@ class SagaException (Exception) :
 
     # --------------------------------------------------------------------------
     #
-    def __str__ (self) :
-        return self.get_message ()
-
-
-    # --------------------------------------------------------------------------
-    #
-    def __repr__ (self) :
-        return "%s\n%s" % (self._message, self._traceback)
-
-
-    # --------------------------------------------------------------------------
-    #
     def _clone (self) :
         """ method is used internally -- see :func:`_get_exception_stack`."""
 


### PR DESCRIPTION
The SAGA exception overwriting the `repr` and `str` methods makes it impossible to *programmatically* inspect the raised exception.  They are also against Python conventions, so this PR removes them - SAGA now (correctly) relies on the `Exception` base class to do the right thing...