### PR TITLE
enhance SMT control in Slurm adaptor 

### DIFF
--- a/src/radical/saga/adaptors/slurm/slurm_job.py
+++ b/src/radical/saga/adaptors/slurm/slurm_job.py
@@ -33,6 +33,8 @@ ASYNC_CALL = cpi_decs.ASYNC_CALL
 
 MONITOR_UPDATE_INTERVAL   = 3  # seconds
 
+SMT_DEFAULT = 1
+
 
 # ------------------------------------------------------------------------------
 # some private defs
@@ -594,7 +596,8 @@ class SLURMJobService(cpi_job.Service):
         for opt in sys_arch.get('options', []):
             constraints.append(opt.lower())
 
-        threads_per_core = sys_arch.get('smt', 1)
+        threads_per_core = int(
+            env.get('RADICAL_SMT') or sys_arch.get('smt') or SMT_DEFAULT)
 
         # check to see what's available in our job description
         # to override defaults

--- a/tests/adaptors/test_slurm.py
+++ b/tests/adaptors/test_slurm.py
@@ -30,7 +30,7 @@ def test_slurm_generator(mocked_handle_ft, mocked_init):
     jd.name                = 'TestSlurm'
     jd.executable          = '/bin/sleep'
     jd.arguments           = ['60']
-    jd.environment         = {'test_env': 15}
+    jd.environment         = {'test_env': 15, 'RADICAL_SMT': 1}
     jd.pre_exec            = ['echo $test_env']
     jd.post_exec           = ['echo $test_env']
     jd.working_directory   = '/home/user'
@@ -44,7 +44,7 @@ def test_slurm_generator(mocked_handle_ft, mocked_init):
     jd.processes_per_host  = PROCESSES_PER_NODE
     jd.total_cpu_count     = PROCESSES_PER_NODE * 2
     # jd.system_architecture = {'gpu': 'p100'}
-    jd.system_architecture = {'options': ['nvme', 'intel'], 'smt': 1}
+    jd.system_architecture = {'options': ['nvme', 'intel'], 'smt': 2}
 
     tgt_script = """#!/bin/sh
 
@@ -62,6 +62,7 @@ def test_slurm_generator(mocked_handle_ft, mocked_init):
 
 ## ENVIRONMENT
 export test_env="15"
+export RADICAL_SMT="1"
 
 ## PRE_EXEC
 echo $test_env


### PR DESCRIPTION
Same approach as for LSF adaptor - check env variable `RADICAL_SMT` first