### PR TITLE
Let shell_wrapper.py close file more promptly.

### DIFF
--- a/src/radical/saga/adaptors/shell/shell_wrapper.py
+++ b/src/radical/saga/adaptors/shell/shell_wrapper.py
@@ -8,5 +8,5 @@ import os
 
 # --------------------------------------------------------------------
 # server side job management script
-_WRAPPER_SCRIPT = open (os.path.dirname(__file__) + '/shell_wrapper.sh').read ()
-
+with open(os.path.dirname(__file__) + '/shell_wrapper.sh') as fh:
+    _WRAPPER_SCRIPT = fh.read ()


### PR DESCRIPTION
With `python -X dev`, I frequently see output like the following.

```
  /home/rp/rp-venv/lib/python3.9/site-packages/radical/saga/adaptors/shell/shell_wrapper.py:11: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/rp/rp-venv/lib/python3.9/site-packages/radical/saga/adaptors/shell/shell_wrapper.sh' mode='r' encoding='UTF-8'>
    _WRAPPER_SCRIPT = open (os.path.dirname(__file__) + '/shell_wrapper.sh').read ()
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
```

This patch should take care of it.