### PR TITLE
Provide a target for Sphinx :py:mod: role.

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,3 +1,5 @@
+.. py:module:: radical.saga
+
 ####################################
 RADICAL-SAGA |version| Documentation
 ####################################


### PR DESCRIPTION
Establish a docutils target for `radical.saga`. Allows the root package module to be linked from inside or outside of the project (via intersphinx through the `objects.inv` file).